### PR TITLE
Feature/dimension tokens

### DIFF
--- a/figmaTokensChakra/$metadata.json
+++ b/figmaTokensChakra/$metadata.json
@@ -23,6 +23,7 @@
     "semantic/light",
     "semantic/dark",
     "Brand-ChakraDemo/light",
-    "Brand-ChakraDemo/dark"
+    "Brand-ChakraDemo/dark",
+    "core/dimension"
   ]
 }

--- a/figmaTokensChakra/core/color.json
+++ b/figmaTokensChakra/core/color.json
@@ -937,6 +937,270 @@
         "value": "hsla(255,0%,100%,0.01)",
         "type": "color"
       }
+    },
+    "BlackAlpha": {
+      "50": {
+        "value": "{color.neutrals.black}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "space": "lch",
+              "value": "0.04"
+            }
+          }
+        }
+      },
+      "100": {
+        "value": "{color.neutrals.black}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "space": "lch",
+              "value": "0.06"
+            }
+          }
+        }
+      },
+      "200": {
+        "value": "{color.neutrals.black}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "space": "lch",
+              "value": "0.08"
+            }
+          }
+        }
+      },
+      "300": {
+        "value": "{color.neutrals.black}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "space": "lch",
+              "value": "0.16"
+            }
+          }
+        }
+      },
+      "400": {
+        "value": "{color.neutrals.black}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "space": "lch",
+              "value": "0.24"
+            }
+          }
+        }
+      },
+      "500": {
+        "value": "{color.neutrals.black}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "space": "lch",
+              "value": "0.36"
+            }
+          }
+        }
+      },
+      "600": {
+        "value": "{color.neutrals.black}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "space": "lch",
+              "value": "0.48"
+            }
+          }
+        }
+      },
+      "700": {
+        "value": "{color.neutrals.black}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "space": "lch",
+              "value": "0.64"
+            }
+          }
+        }
+      },
+      "800": {
+        "value": "{color.neutrals.black}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "space": "lch",
+              "value": "0.80"
+            }
+          }
+        }
+      },
+      "900": {
+        "value": "{color.neutrals.black}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "space": "lch",
+              "value": "0.92"
+            }
+          }
+        }
+      }
+    },
+    "WhiteAlpha": {
+      "50": {
+        "value": "{color.neutrals.white}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "space": "lch",
+              "value": "0.04"
+            }
+          }
+        }
+      },
+      "100": {
+        "value": "{color.neutrals.white}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "space": "lch",
+              "value": "0.06"
+            }
+          }
+        }
+      },
+      "200": {
+        "value": "{color.neutrals.white}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "space": "lch",
+              "value": "0.08"
+            }
+          }
+        }
+      },
+      "300": {
+        "value": "{color.neutrals.white}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "space": "lch",
+              "value": "0.16"
+            }
+          }
+        }
+      },
+      "400": {
+        "value": "{color.neutrals.white}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "space": "lch",
+              "value": "0.24"
+            }
+          }
+        }
+      },
+      "500": {
+        "value": "{color.neutrals.white}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "space": "lch",
+              "value": "0.36"
+            }
+          }
+        }
+      },
+      "600": {
+        "value": "{color.neutrals.white}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "space": "lch",
+              "value": "0.48"
+            }
+          }
+        }
+      },
+      "700": {
+        "value": "{color.neutrals.white}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "space": "lch",
+              "value": "0.64"
+            }
+          }
+        }
+      },
+      "800": {
+        "value": "{color.neutrals.white}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "space": "lch",
+              "value": "0.80"
+            }
+          }
+        }
+      },
+      "900": {
+        "value": "{color.neutrals.white}",
+        "type": "color",
+        "$extensions": {
+          "studio.tokens": {
+            "modify": {
+              "type": "alpha",
+              "space": "lch",
+              "value": "0.92"
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/figmaTokensChakra/core/dimension.json
+++ b/figmaTokensChakra/core/dimension.json
@@ -3,8 +3,8 @@
     "value": "2px",
     "type": "dimension"
   },
-  "dimension": {
-    "size": {
+  "size": {
+    "dimension": {
       "50": {
         "value": "{base}*2",
         "type": "dimension"
@@ -137,7 +137,9 @@
         "value": "{base}*192",
         "type": "dimension"
       }
-    },
+    }
+  },
+  "dimension": {
     "space": {
       "1": {
         "value": "{base}*2",

--- a/figmaTokensChakra/core/dimension.json
+++ b/figmaTokensChakra/core/dimension.json
@@ -139,135 +139,115 @@
       }
     },
     "space": {
-      "50": {
+      "1": {
         "value": "{base}*2",
         "type": "dimension"
       },
-      "75": {
-        "value": "{base}*3",
-        "type": "dimension"
-      },
-      "100": {
+      "2": {
         "value": "{base}*4",
         "type": "dimension"
       },
-      "125": {
-        "value": "{base}*5",
-        "type": "dimension"
-      },
-      "150": {
+      "3": {
         "value": "{base}*6",
         "type": "dimension"
       },
-      "175": {
-        "value": "{base}*7",
-        "type": "dimension"
-      },
-      "200": {
+      "4": {
         "value": "{base}*8",
         "type": "dimension"
       },
-      "225": {
-        "value": "{base}*9",
-        "type": "dimension"
-      },
-      "250": {
+      "5": {
         "value": "{base}*10",
         "type": "dimension"
       },
-      "275": {
-        "value": "{base}*11",
-        "type": "dimension"
-      },
-      "300": {
+      "6": {
         "value": "{base}*12",
         "type": "dimension"
       },
-      "400": {
+      "7": {
+        "value": "{base}*14",
+        "type": "dimension"
+      },
+      "8": {
         "value": "{base}*16",
         "type": "dimension"
       },
-      "450": {
+      "9": {
         "value": "{base}*18",
         "type": "dimension"
       },
-      "500": {
+      "10": {
         "value": "{base}*20",
         "type": "dimension"
       },
-      "600": {
+      "12": {
         "value": "{base}*24",
         "type": "dimension"
       },
-      "700": {
+      "14": {
         "value": "{base}*28",
         "type": "dimension"
       },
-      "800": {
+      "16": {
         "value": "{base}*32",
         "type": "dimension"
       },
-      "900": {
-        "value": "{base}*36",
-        "type": "dimension"
-      },
-      "1000": {
+      "20": {
         "value": "{base}*40",
         "type": "dimension"
       },
-      "1200": {
+      "24": {
         "value": "{base}*48",
         "type": "dimension"
       },
-      "1400": {
+      "28": {
         "value": "{base}*56",
         "type": "dimension"
       },
-      "1600": {
+      "32": {
         "value": "{base}*64",
         "type": "dimension"
       },
-      "1800": {
+      "36": {
         "value": "{base}*72",
         "type": "dimension"
       },
-      "2000": {
+      "40": {
         "value": "{base}*80",
         "type": "dimension"
       },
-      "2200": {
+      "44": {
         "value": "{base}*88",
         "type": "dimension"
       },
-      "2400": {
+      "48": {
         "value": "{base}*96",
         "type": "dimension"
       },
-      "2600": {
+      "52": {
         "value": "{base}*104",
         "type": "dimension"
       },
-      "2800": {
+      "56": {
         "value": "{base}*112",
         "type": "dimension"
       },
-      "3000": {
+      "60": {
         "value": "{base}*120",
         "type": "dimension"
       },
-      "3200": {
+      "64": {
         "value": "{base}*128",
         "type": "dimension"
       },
-      "3400": {
+      "72": {
         "value": "{base}*144",
         "type": "dimension"
       },
-      "3600": {
+      "80": {
         "value": "{base}*160",
         "type": "dimension"
       },
-      "3800": {
+      "96": {
         "value": "{base}*192",
         "type": "dimension"
       }

--- a/figmaTokensChakra/core/dimension.json
+++ b/figmaTokensChakra/core/dimension.json
@@ -137,6 +137,140 @@
         "value": "{base}*192",
         "type": "dimension"
       }
+    },
+    "space": {
+      "50": {
+        "value": "{base}*2",
+        "type": "dimension"
+      },
+      "75": {
+        "value": "{base}*3",
+        "type": "dimension"
+      },
+      "100": {
+        "value": "{base}*4",
+        "type": "dimension"
+      },
+      "125": {
+        "value": "{base}*5",
+        "type": "dimension"
+      },
+      "150": {
+        "value": "{base}*6",
+        "type": "dimension"
+      },
+      "175": {
+        "value": "{base}*7",
+        "type": "dimension"
+      },
+      "200": {
+        "value": "{base}*8",
+        "type": "dimension"
+      },
+      "225": {
+        "value": "{base}*9",
+        "type": "dimension"
+      },
+      "250": {
+        "value": "{base}*10",
+        "type": "dimension"
+      },
+      "275": {
+        "value": "{base}*11",
+        "type": "dimension"
+      },
+      "300": {
+        "value": "{base}*12",
+        "type": "dimension"
+      },
+      "400": {
+        "value": "{base}*16",
+        "type": "dimension"
+      },
+      "450": {
+        "value": "{base}*18",
+        "type": "dimension"
+      },
+      "500": {
+        "value": "{base}*20",
+        "type": "dimension"
+      },
+      "600": {
+        "value": "{base}*24",
+        "type": "dimension"
+      },
+      "700": {
+        "value": "{base}*28",
+        "type": "dimension"
+      },
+      "800": {
+        "value": "{base}*32",
+        "type": "dimension"
+      },
+      "900": {
+        "value": "{base}*36",
+        "type": "dimension"
+      },
+      "1000": {
+        "value": "{base}*40",
+        "type": "dimension"
+      },
+      "1200": {
+        "value": "{base}*48",
+        "type": "dimension"
+      },
+      "1400": {
+        "value": "{base}*56",
+        "type": "dimension"
+      },
+      "1600": {
+        "value": "{base}*64",
+        "type": "dimension"
+      },
+      "1800": {
+        "value": "{base}*72",
+        "type": "dimension"
+      },
+      "2000": {
+        "value": "{base}*80",
+        "type": "dimension"
+      },
+      "2200": {
+        "value": "{base}*88",
+        "type": "dimension"
+      },
+      "2400": {
+        "value": "{base}*96",
+        "type": "dimension"
+      },
+      "2600": {
+        "value": "{base}*104",
+        "type": "dimension"
+      },
+      "2800": {
+        "value": "{base}*112",
+        "type": "dimension"
+      },
+      "3000": {
+        "value": "{base}*120",
+        "type": "dimension"
+      },
+      "3200": {
+        "value": "{base}*128",
+        "type": "dimension"
+      },
+      "3400": {
+        "value": "{base}*144",
+        "type": "dimension"
+      },
+      "3600": {
+        "value": "{base}*160",
+        "type": "dimension"
+      },
+      "3800": {
+        "value": "{base}*192",
+        "type": "dimension"
+      }
     }
   }
 }

--- a/figmaTokensChakra/core/dimension.json
+++ b/figmaTokensChakra/core/dimension.json
@@ -139,8 +139,8 @@
       }
     }
   },
-  "dimension": {
-    "space": {
+  "space": {
+    "dimension": {
       "1": {
         "value": "{base}*2",
         "type": "dimension"

--- a/figmaTokensChakra/core/dimension.json
+++ b/figmaTokensChakra/core/dimension.json
@@ -45,95 +45,95 @@
       "type": "dimension"
     },
     "300": {
-      "value": "{base}*2",
+      "value": "{base}*12",
       "type": "dimension"
     },
     "400": {
-      "value": "{base}*2",
+      "value": "{base}*16",
       "type": "dimension"
     },
     "450": {
-      "value": "{base}*2",
+      "value": "{base}*18",
       "type": "dimension"
     },
     "500": {
-      "value": "{base}*2",
+      "value": "{base}*20",
       "type": "dimension"
     },
     "600": {
-      "value": "{base}*2",
+      "value": "{base}*24",
       "type": "dimension"
     },
     "700": {
-      "value": "{base}*2",
+      "value": "{base}*28",
       "type": "dimension"
     },
     "800": {
-      "value": "{base}*2",
+      "value": "{base}*32",
       "type": "dimension"
     },
     "900": {
-      "value": "{base}*2",
+      "value": "{base}*36",
       "type": "dimension"
     },
     "1000": {
-      "value": "{base}*2",
+      "value": "{base}*40",
       "type": "dimension"
     },
     "1200": {
-      "value": "{base}*2",
+      "value": "{base}*48",
       "type": "dimension"
     },
     "1400": {
-      "value": "{base}*2",
+      "value": "{base}*56",
       "type": "dimension"
     },
     "1600": {
-      "value": "{base}*2",
+      "value": "{base}*64",
       "type": "dimension"
     },
     "1800": {
-      "value": "{base}*2",
+      "value": "{base}*72",
       "type": "dimension"
     },
     "2000": {
-      "value": "{base}*2",
+      "value": "{base}*80",
       "type": "dimension"
     },
     "2200": {
-      "value": "{base}*2",
+      "value": "{base}*88",
       "type": "dimension"
     },
     "2400": {
-      "value": "{base}*2",
+      "value": "{base}*96",
       "type": "dimension"
     },
     "2600": {
-      "value": "{base}*2",
+      "value": "{base}*104",
       "type": "dimension"
     },
     "2800": {
-      "value": "{base}*2",
+      "value": "{base}*112",
       "type": "dimension"
     },
     "3000": {
-      "value": "{base}*2",
+      "value": "{base}*120",
       "type": "dimension"
     },
     "3200": {
-      "value": "{base}*2",
+      "value": "{base}*128",
       "type": "dimension"
     },
     "3400": {
-      "value": "{base}*2",
+      "value": "{base}*144",
       "type": "dimension"
     },
-    "{base}*200": {
-      "value": "{base}*2",
+    "3600": {
+      "value": "{base}*160",
       "type": "dimension"
     },
     "3800": {
-      "value": "{base}*2",
+      "value": "{base}*192",
       "type": "dimension"
     }
   }

--- a/figmaTokensChakra/core/dimension.json
+++ b/figmaTokensChakra/core/dimension.json
@@ -4,137 +4,139 @@
     "type": "dimension"
   },
   "dimension": {
-    "50": {
-      "value": "{base}*2",
-      "type": "dimension"
-    },
-    "75": {
-      "value": "{base}*3",
-      "type": "dimension"
-    },
-    "100": {
-      "value": "{base}*4",
-      "type": "dimension"
-    },
-    "125": {
-      "value": "{base}*5",
-      "type": "dimension"
-    },
-    "150": {
-      "value": "{base}*6",
-      "type": "dimension"
-    },
-    "175": {
-      "value": "{base}*7",
-      "type": "dimension"
-    },
-    "200": {
-      "value": "{base}*8",
-      "type": "dimension"
-    },
-    "225": {
-      "value": "{base}*9",
-      "type": "dimension"
-    },
-    "250": {
-      "value": "{base}*10",
-      "type": "dimension"
-    },
-    "275": {
-      "value": "{base}*11",
-      "type": "dimension"
-    },
-    "300": {
-      "value": "{base}*12",
-      "type": "dimension"
-    },
-    "400": {
-      "value": "{base}*16",
-      "type": "dimension"
-    },
-    "450": {
-      "value": "{base}*18",
-      "type": "dimension"
-    },
-    "500": {
-      "value": "{base}*20",
-      "type": "dimension"
-    },
-    "600": {
-      "value": "{base}*24",
-      "type": "dimension"
-    },
-    "700": {
-      "value": "{base}*28",
-      "type": "dimension"
-    },
-    "800": {
-      "value": "{base}*32",
-      "type": "dimension"
-    },
-    "900": {
-      "value": "{base}*36",
-      "type": "dimension"
-    },
-    "1000": {
-      "value": "{base}*40",
-      "type": "dimension"
-    },
-    "1200": {
-      "value": "{base}*48",
-      "type": "dimension"
-    },
-    "1400": {
-      "value": "{base}*56",
-      "type": "dimension"
-    },
-    "1600": {
-      "value": "{base}*64",
-      "type": "dimension"
-    },
-    "1800": {
-      "value": "{base}*72",
-      "type": "dimension"
-    },
-    "2000": {
-      "value": "{base}*80",
-      "type": "dimension"
-    },
-    "2200": {
-      "value": "{base}*88",
-      "type": "dimension"
-    },
-    "2400": {
-      "value": "{base}*96",
-      "type": "dimension"
-    },
-    "2600": {
-      "value": "{base}*104",
-      "type": "dimension"
-    },
-    "2800": {
-      "value": "{base}*112",
-      "type": "dimension"
-    },
-    "3000": {
-      "value": "{base}*120",
-      "type": "dimension"
-    },
-    "3200": {
-      "value": "{base}*128",
-      "type": "dimension"
-    },
-    "3400": {
-      "value": "{base}*144",
-      "type": "dimension"
-    },
-    "3600": {
-      "value": "{base}*160",
-      "type": "dimension"
-    },
-    "3800": {
-      "value": "{base}*192",
-      "type": "dimension"
+    "size": {
+      "50": {
+        "value": "{base}*2",
+        "type": "dimension"
+      },
+      "75": {
+        "value": "{base}*3",
+        "type": "dimension"
+      },
+      "100": {
+        "value": "{base}*4",
+        "type": "dimension"
+      },
+      "125": {
+        "value": "{base}*5",
+        "type": "dimension"
+      },
+      "150": {
+        "value": "{base}*6",
+        "type": "dimension"
+      },
+      "175": {
+        "value": "{base}*7",
+        "type": "dimension"
+      },
+      "200": {
+        "value": "{base}*8",
+        "type": "dimension"
+      },
+      "225": {
+        "value": "{base}*9",
+        "type": "dimension"
+      },
+      "250": {
+        "value": "{base}*10",
+        "type": "dimension"
+      },
+      "275": {
+        "value": "{base}*11",
+        "type": "dimension"
+      },
+      "300": {
+        "value": "{base}*12",
+        "type": "dimension"
+      },
+      "400": {
+        "value": "{base}*16",
+        "type": "dimension"
+      },
+      "450": {
+        "value": "{base}*18",
+        "type": "dimension"
+      },
+      "500": {
+        "value": "{base}*20",
+        "type": "dimension"
+      },
+      "600": {
+        "value": "{base}*24",
+        "type": "dimension"
+      },
+      "700": {
+        "value": "{base}*28",
+        "type": "dimension"
+      },
+      "800": {
+        "value": "{base}*32",
+        "type": "dimension"
+      },
+      "900": {
+        "value": "{base}*36",
+        "type": "dimension"
+      },
+      "1000": {
+        "value": "{base}*40",
+        "type": "dimension"
+      },
+      "1200": {
+        "value": "{base}*48",
+        "type": "dimension"
+      },
+      "1400": {
+        "value": "{base}*56",
+        "type": "dimension"
+      },
+      "1600": {
+        "value": "{base}*64",
+        "type": "dimension"
+      },
+      "1800": {
+        "value": "{base}*72",
+        "type": "dimension"
+      },
+      "2000": {
+        "value": "{base}*80",
+        "type": "dimension"
+      },
+      "2200": {
+        "value": "{base}*88",
+        "type": "dimension"
+      },
+      "2400": {
+        "value": "{base}*96",
+        "type": "dimension"
+      },
+      "2600": {
+        "value": "{base}*104",
+        "type": "dimension"
+      },
+      "2800": {
+        "value": "{base}*112",
+        "type": "dimension"
+      },
+      "3000": {
+        "value": "{base}*120",
+        "type": "dimension"
+      },
+      "3200": {
+        "value": "{base}*128",
+        "type": "dimension"
+      },
+      "3400": {
+        "value": "{base}*144",
+        "type": "dimension"
+      },
+      "3600": {
+        "value": "{base}*160",
+        "type": "dimension"
+      },
+      "3800": {
+        "value": "{base}*192",
+        "type": "dimension"
+      }
     }
   }
 }

--- a/figmaTokensChakra/core/dimension.json
+++ b/figmaTokensChakra/core/dimension.json
@@ -43,6 +43,98 @@
     "275": {
       "value": "{base}*11",
       "type": "dimension"
+    },
+    "300": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "400": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "450": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "500": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "600": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "700": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "800": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "900": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "1000": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "1200": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "1400": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "1600": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "1800": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "2000": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "2200": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "2400": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "2600": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "2800": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "3000": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "3200": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "3400": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "{base}*200": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "3800": {
+      "value": "{base}*2",
+      "type": "dimension"
     }
   }
 }

--- a/figmaTokensChakra/core/dimension.json
+++ b/figmaTokensChakra/core/dimension.json
@@ -1,0 +1,48 @@
+{
+  "base": {
+    "value": "2px",
+    "type": "dimension"
+  },
+  "dimension": {
+    "50": {
+      "value": "{base}*2",
+      "type": "dimension"
+    },
+    "75": {
+      "value": "{base}*3",
+      "type": "dimension"
+    },
+    "100": {
+      "value": "{base}*4",
+      "type": "dimension"
+    },
+    "125": {
+      "value": "{base}*5",
+      "type": "dimension"
+    },
+    "150": {
+      "value": "{base}*6",
+      "type": "dimension"
+    },
+    "175": {
+      "value": "{base}*7",
+      "type": "dimension"
+    },
+    "200": {
+      "value": "{base}*8",
+      "type": "dimension"
+    },
+    "225": {
+      "value": "{base}*9",
+      "type": "dimension"
+    },
+    "250": {
+      "value": "{base}*10",
+      "type": "dimension"
+    },
+    "275": {
+      "value": "{base}*11",
+      "type": "dimension"
+    }
+  }
+}


### PR DESCRIPTION
**What is this change?**
1. Sizing token group has been added within the `dimension type`. The value of the tokens are referencing the `base token value '2'`, using it as the multiplier across the sizing scale. 
2. Spacing token group has been added within the `dimension type`. The naming convention of the group follows the Chakra UI Docs for spacing. The value of the tokens are referencing `the base token '2'`, using it as the multiplier across the scale. 

**What does it fix?**
The dimension type allows for _central_ control over `spacing` and `sizing` tokens respectively; also allowing for more flexibility across the system.

**Is this a bug fix or a feature? Does it break any existing functionality or force me to update to a new version?**
This is a feature, and does no break any existing functionality, nor requires an update to a new version.

**How has it been tested?**
Have applied the different dimensions on frames.